### PR TITLE
Bring Inline with JSONRPC 2.0 Spec

### DIFF
--- a/lib/jsonrpc.js
+++ b/lib/jsonrpc.js
@@ -14,11 +14,7 @@ var JSONRpcClient = function (host, port, requestPath) {
         if(this.wsClient === null) {
             this.wsClient = new WebSocket(this.wsUrl)
         }
-        var requestJSON = JSON.stringify({
-            'id': (new Date()).getTime(),
-            'method': method,
-            'params': params
-        })
+        var requestJSON = buildRequestJSON(method, params)
         var that = this
         function sendMessage(message) {
             if(that.wsClient === null) return
@@ -47,11 +43,7 @@ var JSONRpcClient = function (host, port, requestPath) {
         this.wsClient = null
     }
     this.call = function (method, params, callback) {
-        var requestJSON = JSON.stringify({
-            'id': (new Date()).getTime(),
-            'method': method,
-            'params': params
-        })
+        var requestJSON = buildRequestJSON(method, params)
         var headers = {
             'Content-Type': 'application/json',
             'Cache-Control': 'no-cache',
@@ -92,6 +84,15 @@ var JSONRpcClient = function (host, port, requestPath) {
                 else resolve(ret)
             })
         })
+    }
+
+    function buildRequestJSON(method, params) {
+      return JSON.stringify({
+          'jsonrpc' : '2.0',
+          'id': (new Date()).getTime(),
+          'method': method,
+          'params': params
+      })
     }
 }
 


### PR DESCRIPTION
As per the [JSON RPC 2.0 spec](http://www.jsonrpc.org/specification), `jsonrpc` needs to be set in the request to `2.0`, this was causing issues with my java based rpc server and i'm sure it will for many other.

I moved the request building logic to a function as it was being duplicated for web socket requests